### PR TITLE
Add pytest test for home route

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # Content Marketplace
 A Flask-based decentralized content marketplace.
-##
+
+## Testing
+
+Install the dependencies and run the test suite using `pytest`:
+
+```bash
+pip install -r requirements.txt
+pytest
+```
+

--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ app = Flask(__name__)
 # Define a route for the homepage
 @app.route('/')
 def home():
-    return "Welcome to the Digital Content Marketplace!"
+    return "Welcome to the Decentralized Content Marketplace!"
 
 # Run the application
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ itsdangerous==2.2.0
 Jinja2==3.1.4
 MarkupSafe==3.0.1
 Werkzeug==3.0.4
+pytest==8.1.1

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,7 @@
+import pytest
+from app import app
+
+def test_homepage():
+    with app.test_client() as client:
+        response = client.get('/')
+        assert response.get_data(as_text=True) == "Welcome to the Decentralized Content Marketplace!"


### PR DESCRIPTION
## Summary
- add basic pytest test for home route
- update app message
- include pytest in requirements
- document running tests in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement blinker==1.8.2)*

------
https://chatgpt.com/codex/tasks/task_e_6841c6009374832299fc3e1bcf00d8b7